### PR TITLE
Fix ObjectMapper bean config

### DIFF
--- a/applications/app-service/src/main/java/co/com/bancolombia/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/co/com/bancolombia/config/ObjectMapperConfig.java
@@ -1,10 +1,13 @@
 package co.com.bancolombia.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class ObjectMapper {
+public class ObjectMapperConfig {
 
+    @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
     }


### PR DESCRIPTION
## Summary
- rename ObjectMapper configuration file
- return Jackson `ObjectMapper` as a Spring bean

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850c3aa13108325aeb892138994772c