### PR TITLE
Fix enum name BusinessErrorMessage

### DIFF
--- a/domain/model/src/main/java/co/com/bancolombia/exceptions/BusinessErrorMessage.java
+++ b/domain/model/src/main/java/co/com/bancolombia/exceptions/BusinessErrorMessage.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public enum BussinesErrorMessage {
+public enum BusinessErrorMessage {
 
     ERROR_BAD_REQUEST("400", "Error en la peticion", "BP400", "Sucedio un error inesperado en la peticion"),
     ERROR_MAPPING_VALIDATE_REQUEST("499", "Error en la peticion", "BP499", "Sucedio un error inesperado en la peticion - 499")
@@ -21,15 +21,15 @@ public enum BussinesErrorMessage {
     private final String errorCode;
     private final String errorMessage;
 
-    private static final Map<String, BussinesErrorMessage> mapEnum = new HashMap<>();
+    private static final Map<String, BusinessErrorMessage> mapEnum = new HashMap<>();
     static {
-        for (BussinesErrorMessage status : BussinesErrorMessage.values()) {
+        for (BusinessErrorMessage status : BusinessErrorMessage.values()) {
             mapEnum.put(status.status, status);
             System.out.println("Echo - ErrorCode: " + status.status + " - Title - " + status.title);
         }
     }
 
-    public static BussinesErrorMessage getEnumStatusCode(String status) {
+    public static BusinessErrorMessage getEnumStatusCode(String status) {
         return mapEnum.get(status);
     }
 

--- a/domain/model/src/main/java/co/com/bancolombia/exceptions/CustomerBusinessException.java
+++ b/domain/model/src/main/java/co/com/bancolombia/exceptions/CustomerBusinessException.java
@@ -2,16 +2,18 @@ package co.com.bancolombia.exceptions;
 
 import lombok.*;
 
+import co.com.bancolombia.exceptions.BusinessErrorMessage;
+
 import java.io.Serializable;
 
 @Getter
 public class CustomerBusinessException extends RuntimeException {
-    private final BussinesErrorMessage bussinesErrorMessage;
+    private final BusinessErrorMessage businessErrorMessage;
     private final ResponseBackEnd responseBackEnd;
 
-    public CustomerBusinessException(BussinesErrorMessage bussinesErrorMessage, ResponseBackEnd responseBackEnd) {
-        super(bussinesErrorMessage.getErrorMessage());
-        this.bussinesErrorMessage = bussinesErrorMessage;
+    public CustomerBusinessException(BusinessErrorMessage businessErrorMessage, ResponseBackEnd responseBackEnd) {
+        super(businessErrorMessage.getErrorMessage());
+        this.businessErrorMessage = businessErrorMessage;
         this.responseBackEnd = responseBackEnd;
     }
 

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/ReactiveWebFluxUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/ReactiveWebFluxUseCase.java
@@ -1,14 +1,14 @@
 package co.com.bancolombia.usecase;
 
 
-import co.com.bancolombia.exceptions.BussinesErrorMessage;
+import co.com.bancolombia.exceptions.BusinessErrorMessage;
 import co.com.bancolombia.exceptions.CustomerBusinessException;
 import co.com.bancolombia.gateway.UserGateway;
 import co.com.bancolombia.model.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
-import static co.com.bancolombia.exceptions.BussinesErrorMessage.ERROR_BAD_REQUEST;
+import static co.com.bancolombia.exceptions.BusinessErrorMessage.ERROR_BAD_REQUEST;
 
 @RequiredArgsConstructor
 public class ReactiveWebFluxUseCase {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/utils/ValidateRequest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/utils/ValidateRequest.java
@@ -1,7 +1,7 @@
 package co.com.bancolombia.api.utils;
 
 import co.com.bancolombia.api.scaffold.request.UserRequest;
-import co.com.bancolombia.exceptions.BussinesErrorMessage;
+import co.com.bancolombia.exceptions.BusinessErrorMessage;
 import co.com.bancolombia.exceptions.CustomerBusinessException;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class ValidateRequest {
         }
         FieldError fieldError = errors.getFieldError("userRequest");
         String code = (fieldError != null) ? fieldError.getCode() : "499";
-        var enumError = BussinesErrorMessage.getEnumStatusCode(code);
+        var enumError = BusinessErrorMessage.getEnumStatusCode(code);
         var backEnd = CustomerBusinessException.ResponseBackEnd.builder().build();
         return Mono.error(() -> new CustomerBusinessException(enumError, backEnd));
     }


### PR DESCRIPTION
## Summary
- rename `BussinesErrorMessage` enum to `BusinessErrorMessage`
- update imports and usage across modules

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c2b4c9d88325b21575d207133741