### PR TITLE
Add functional router and handler

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/handler/UserHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/handler/UserHandler.java
@@ -1,0 +1,48 @@
+package co.com.bancolombia.api.handler;
+
+import co.com.bancolombia.api.exceptions.BusinessException;
+import co.com.bancolombia.api.scaffold.request.UserRequest;
+import co.com.bancolombia.api.scaffold.response.Meta;
+import co.com.bancolombia.api.scaffold.response.ReactiveWebFluxResponse;
+import co.com.bancolombia.api.scaffold.response.ResponseEntityBuilder;
+import co.com.bancolombia.api.utils.ValidateRequest;
+import co.com.bancolombia.exceptions.CustomerBusinessException;
+import co.com.bancolombia.usecase.ReactiveWebFluxUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@Component
+public class UserHandler {
+
+    private final ReactiveWebFluxUseCase reactiveWebFluxUseCase;
+    private final ValidateRequest validateRequest;
+    private final ResponseEntityBuilder responseEntityBuilder;
+
+    public Mono<ServerResponse> handle(ServerRequest serverRequest) {
+        return serverRequest.bodyToMono(UserRequest.class)
+                .flatMap(validateRequest::validateRequest)
+                .flatMap(req -> reactiveWebFluxUseCase.userGateway(req.getData().getMessage()))
+                .flatMap(userResponse -> {
+                    Meta meta = responseEntityBuilder.buildMeta(LocalDate.now().toString(), "user-operation");
+                    return responseEntityBuilder.buildResponse(meta, userResponse);
+                })
+                .flatMap(resp -> ServerResponse.ok().bodyValue(resp))
+                .onErrorResume(CustomerBusinessException.class, ex -> {
+                    Meta meta = responseEntityBuilder.buildMeta(LocalDate.now().toString(), "user-operation");
+                    BusinessException businessException = BusinessException.builder()
+                            .exceptionCode(ex.getBusinessErrorMessage().getErrorCode())
+                            .description(ex.getBusinessErrorMessage().getErrorMessage())
+                            .statusCode(Integer.parseInt(ex.getBusinessErrorMessage().getStatus()))
+                            .title(ex.getBusinessErrorMessage().getTitle())
+                            .build();
+                    return responseEntityBuilder.buildErrorResumen(meta, businessException)
+                            .flatMap(error -> ServerResponse.status(businessException.statusCode()).bodyValue(error));
+                });
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/router/UserRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/router/UserRouterRest.java
@@ -1,0 +1,23 @@
+package co.com.bancolombia.api.router;
+
+import co.com.bancolombia.api.handler.UserHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+@RequiredArgsConstructor
+public class UserRouterRest {
+
+    private final UserHandler userHandler;
+
+    @Bean
+    public RouterFunction<ServerResponse> route() {
+        return RouterFunctions.route()
+                .POST("/user", userHandler::handle)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UserHandler` to orchestrate request validation, use case invocation, and error management
- configure `UserRouterRest` with functional routing for `/user`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850c69a0be08325968626cee7232b3b