### PR TITLE
Add Postgres consentimientos endpoint

### DIFF
--- a/applications/app-service/src/main/java/co/com/bancolombia/config/PostgresConfig.java
+++ b/applications/app-service/src/main/java/co/com/bancolombia/config/PostgresConfig.java
@@ -1,0 +1,25 @@
+package co.com.bancolombia.config;
+
+import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.boot.r2dbc.ConnectionFactoryBuilder;
+
+@Configuration
+public class PostgresConfig extends AbstractR2dbcConfiguration {
+
+    @Override
+    public ConnectionFactory connectionFactory() {
+        return ConnectionFactoryBuilder.withUrl("r2dbc:postgresql://localhost:5432/sukaPg")
+                .username("postgres")
+                .password("posgrest")
+                .build();
+    }
+
+    @Bean
+    public DatabaseClient databaseClient(ConnectionFactory connectionFactory) {
+        return DatabaseClient.create(connectionFactory);
+    }
+}

--- a/domain/model/src/main/java/co/com/bancolombia/gateway/ConsentimientoGateway.java
+++ b/domain/model/src/main/java/co/com/bancolombia/gateway/ConsentimientoGateway.java
@@ -1,0 +1,8 @@
+package co.com.bancolombia.gateway;
+
+import co.com.bancolombia.model.consentimiento.Consentimiento;
+import reactor.core.publisher.Flux;
+
+public interface ConsentimientoGateway {
+    Flux<Consentimiento> findAll();
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/consentimiento/Consentimiento.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/consentimiento/Consentimiento.java
@@ -1,0 +1,21 @@
+package co.com.bancolombia.model.consentimiento;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class Consentimiento {
+    private Integer id;
+    private String nombre;
+    private String correo;
+    private LocalDateTime fechaRegistro;
+    private Map<String, Object> consentimiento;
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/consentimiento/ConsentimientoDto.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/consentimiento/ConsentimientoDto.java
@@ -1,0 +1,21 @@
+package co.com.bancolombia.model.consentimiento;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class ConsentimientoDto {
+    private Integer id;
+    private String nombre;
+    private String correo;
+    private LocalDateTime fechaRegistro;
+    private Map<String, Object> consentimiento;
+}

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/ConsentimientoUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/ConsentimientoUseCase.java
@@ -1,0 +1,35 @@
+package co.com.bancolombia.usecase;
+
+import co.com.bancolombia.gateway.ConsentimientoGateway;
+import co.com.bancolombia.model.consentimiento.ConsentimientoDto;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class ConsentimientoUseCase {
+
+    private final ConsentimientoGateway gateway;
+
+    public Flux<Set<ConsentimientoDto>> obtenerConsentimientos() {
+        Instant start = Instant.now();
+        return gateway.findAll()
+                .map(cons -> ConsentimientoDto.builder()
+                        .id(cons.getId())
+                        .nombre(cons.getNombre())
+                        .correo(cons.getCorreo())
+                        .fechaRegistro(cons.getFechaRegistro())
+                        .consentimiento(cons.getConsentimiento())
+                        .build())
+                .collect(Collectors.toSet())
+                .flux()
+                .doOnNext(set -> {
+                    long ms = Duration.between(start, Instant.now()).toMillis();
+                    System.out.println("Tiempo consulta consentimientos: " + ms + "ms");
+                });
+    }
+}

--- a/infrastructure/driven-adapters/postgres/src/main/java/co/com/bancolombia/postgres/PostgresConsentimientoRepository.java
+++ b/infrastructure/driven-adapters/postgres/src/main/java/co/com/bancolombia/postgres/PostgresConsentimientoRepository.java
@@ -1,0 +1,29 @@
+package co.com.bancolombia.postgres;
+
+import co.com.bancolombia.gateway.ConsentimientoGateway;
+import co.com.bancolombia.model.consentimiento.Consentimiento;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+@RequiredArgsConstructor
+public class PostgresConsentimientoRepository implements ConsentimientoGateway {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Flux<Consentimiento> findAll() {
+        String query = "SELECT id, nombre, correo, fecha_registro, consentimiento FROM consentimientos";
+        return databaseClient.sql(query)
+                .map(row -> Consentimiento.builder()
+                        .id(row.get("id", Integer.class))
+                        .nombre(row.get("nombre", String.class))
+                        .correo(row.get("correo", String.class))
+                        .fechaRegistro(row.get("fecha_registro", java.time.LocalDateTime.class))
+                        .consentimiento(row.get("consentimiento", java.util.Map.class))
+                        .build())
+                .all();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/handler/ConsentimientoHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/handler/ConsentimientoHandler.java
@@ -1,0 +1,21 @@
+package co.com.bancolombia.api.handler;
+
+import co.com.bancolombia.usecase.ConsentimientoUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class ConsentimientoHandler {
+
+    private final ConsentimientoUseCase useCase;
+
+    public Mono<ServerResponse> handle(ServerRequest serverRequest) {
+        return useCase.obtenerConsentimientos()
+                .flatMap(set -> ServerResponse.ok().bodyValue(set))
+                .next();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/router/ConsentimientoRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/router/ConsentimientoRouter.java
@@ -1,0 +1,23 @@
+package co.com.bancolombia.api.router;
+
+import co.com.bancolombia.api.handler.ConsentimientoHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+@RequiredArgsConstructor
+public class ConsentimientoRouter {
+
+    private final ConsentimientoHandler handler;
+
+    @Bean
+    public RouterFunction<ServerResponse> consentimientoRoute() {
+        return RouterFunctions.route()
+                .GET("/consentimientos", handler::handle)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add Postgres configuration
- add consentimiento model and DTO
- create gateway and use case for consentimientos
- implement Postgres repository
- expose new router and handler for retrieving consentimientos

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*


------
https://chatgpt.com/codex/tasks/task_e_687518f0255483258d8bc89e3ed86cd2